### PR TITLE
Enhance release workflow to support manual triggers and improve error handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,22 @@ on:
     types: [closed]
     branches:
       - main
+  workflow_dispatch: # Allows manual triggering of workflow
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true
+    # Modified condition to allow both PR merges and manual triggers
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Bump version and push tag
         id: tag_version
@@ -25,12 +32,24 @@ jobs:
 
       - name: Update manifest.json
         run: |
+          if [ ! -f "custom_components/alliant_energy/manifest.json" ]; then
+            echo "Error: manifest.json not found"
+            exit 1
+          fi
+
           version="${{ steps.tag_version.outputs.new_tag }}"
           version="${version#v}"  # Remove 'v' prefix
           manifest_path="custom_components/alliant_energy/manifest.json"
-          jq --arg version "$version" '.version = $version' $manifest_path > temp.json && mv temp.json $manifest_path
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+
+          if ! jq --arg version "$version" '.version = $version' $manifest_path > temp.json; then
+            echo "Error: Failed to update manifest.json"
+            exit 1
+          fi
+
+          mv temp.json $manifest_path
+
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
           git add $manifest_path
           git commit -m "chore: bump manifest version to $version"
           git push


### PR DESCRIPTION
# Summary
This pull request updates the GitHub Actions workflow for the automated release process. The changes allow for manual triggering of the workflow and enhance error handling for manifest version updates.

# Background
The previous workflow was limited to triggering on merged pull requests. This update introduces a new feature to manually invoke the workflow. Additionally, the workflow now includes error checks to ensure that `manifest.json` exists and is updated correctly, which improves the reliability of the release process.

# Changes
- Added the ability to manually trigger the workflow with `workflow_dispatch`.
- Modified the condition for the 'release' job to allow execution on manual triggers or merged pull requests.
- Included error checks to ensure that the `custom_components/alliant_energy/manifest.json` file exists before attempting to update it.
- Registered proper error handling if the JSON update fails.
- Updated GitHub Actions user configuration to use the GitHub Actions bot email.

# Closed Issues
- No issues were directly referenced in the commit messages.

# Joy
A new way to flow,  
Manual triggers set in place,  
Errors now controlled.  
🌟🔧✨